### PR TITLE
Allow admins to kick members from a team

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -4,6 +4,8 @@ import discord
 from discord.ext import commands
 from discord import app_commands
 
+from discord.app_commands.errors import CommandInvokeError
+
 from typing import Literal
 
 from src.queries.puzzle import (
@@ -200,11 +202,15 @@ class Admin(commands.GroupCog):
             return
 
         elif status == "deleted":
-            await interaction.followup.send(
-                f"{member.display_name} has been successfully kicked from the team. "
-                + "Since the team is empty, the corresponding roles and channels will be deleted.",
-                ephemeral=True,
-            )
+            try:
+                await interaction.followup.send(
+                    f"{member.display_name} has been successfully kicked from the team. "
+                    + "Since the team is empty, the corresponding roles and channels will be deleted.",
+                    ephemeral=True,
+                )
+            except CommandInvokeError:
+                return
+
             return
 
 

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -182,7 +182,7 @@ class Admin(commands.GroupCog):
         name="remove_member", description="Forcibly removes a member from a team."
     )
     @commands.has_role(EXEC_ID)
-    async def kick_member(
+    async def remove_member(
         self, interaction: discord.Interaction, member: discord.Member
     ):
         await interaction.response.defer(ephemeral=True)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -13,6 +13,8 @@ from src.queries.puzzle import (
     create_puzzle,
     delete_puzzle,
 )
+from src.queries.player import get_player, remove_player
+from src.queries.team import get_team, get_team_members, remove_team
 
 from src.config import config
 
@@ -170,6 +172,64 @@ class Admin(commands.GroupCog):
 
         await interaction.followup.send(
             f"Hints will now be redirected to <#{channel.id}>"
+        )
+
+    @app_commands.command(
+        name="kick_member", description="Forcibly removes a member from a team."
+    )
+    @commands.has_role(EXEC_ID)
+    async def kick_member(
+        self, interaction: discord.Interaction, member: discord.Member
+    ):
+        await interaction.response.defer(ephemeral=True)
+
+        guild = interaction.guild
+
+        # get player object from member
+        player = await get_player(str(member.id))
+
+        if not player:
+            await interaction.followup.send(
+                f"{member.display_name} is not part of a team."
+            )
+            return
+
+        team_name = player.team_name
+
+        team = await get_team(team_name)
+        team_role_id = int(team.team_role_id)
+        role = guild.get_role(team_role_id)
+
+        # remove their team role
+        await member.remove_roles(role)
+
+        # delete player
+        await remove_player(str(member.id))
+
+        # delete team if no more members
+        team_members = await get_team_members(team_name)
+
+        if team_members:
+            await interaction.followup.send(
+                f"{member.display_name} has been successfully kicked from {team_name}."
+            )
+            return
+
+        category_channel = guild.get_channel(int(team.category_channel_id))
+        text_channel = guild.get_channel(int(team.text_channel_id))
+        voice_channel = guild.get_channel(int(team.voice_channel_id))
+
+        # delete roles and channels
+        await text_channel.delete()
+        await voice_channel.delete()
+        await category_channel.delete()
+        await role.delete()
+
+        await remove_team(team_name)
+
+        await interaction.followup.send(
+            f"{member.display_name} has been successfully kicked from {team_name}. "
+            + "Since the team is empty, the corresponding roles and channels will be deleted."
         )
 
 

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -183,7 +183,29 @@ class Admin(commands.GroupCog):
     async def kick_member(
         self, interaction: discord.Interaction, member: discord.Member
     ):
-        await remove_member_from_team(interaction, member, True)
+        await interaction.response.defer(ephemeral=True)
+        status = await remove_member_from_team(interaction.guild, member)
+
+        if status is None:
+            await interaction.followup.send(
+                f"{member.display_name} is not part of a team.", ephemeral=True
+            )
+            return
+
+        elif status == "removed":
+            await interaction.followup.send(
+                f"{member.display_name} has been successfully kicked from the team.",
+                ephemeral=True,
+            )
+            return
+
+        elif status == "deleted":
+            await interaction.followup.send(
+                f"{member.display_name} has been successfully kicked from the team. "
+                + "Since the team is empty, the corresponding roles and channels will be deleted.",
+                ephemeral=True,
+            )
+            return
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -179,7 +179,7 @@ class Admin(commands.GroupCog):
         )
 
     @app_commands.command(
-        name="kick_member", description="Forcibly removes a member from a team."
+        name="remove_member", description="Forcibly removes a member from a team."
     )
     @commands.has_role(EXEC_ID)
     async def kick_member(

--- a/cogs/team.py
+++ b/cogs/team.py
@@ -2,6 +2,8 @@ import discord
 from discord.ext import commands
 from discord import app_commands
 
+from discord.app_commands.errors import CommandInvokeError
+
 import src.queries.team as team_query
 import src.queries.player as player_query
 
@@ -98,10 +100,14 @@ class Team(commands.GroupCog):
             return
 
         elif status == "deleted":
-            await interaction.followup.send(
-                "You have left the team. Since there are no members left, the channels will be deleted.",
-                ephemeral=True,
-            )
+            try:
+                await interaction.followup.send(
+                    "You have left the team. Since there are no members left, the channels will be deleted.",
+                    ephemeral=True,
+                )
+            except CommandInvokeError:
+                return
+
             return
 
     @app_commands.command(

--- a/cogs/team.py
+++ b/cogs/team.py
@@ -81,9 +81,28 @@ class Team(commands.GroupCog):
 
     @app_commands.command(name="leave", description="Leave your current team.")
     async def leave_team(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+
         user = interaction.user
 
-        await remove_member_from_team(interaction, user, False)
+        status = await remove_member_from_team(interaction.guild, user)
+
+        if status is None:
+            await interaction.followup.send(
+                "You are not part of a team.", ephemeral=True
+            )
+            return
+
+        elif status == "removed":
+            await interaction.followup.send("You have left the team.", ephemeral=True)
+            return
+
+        elif status == "deleted":
+            await interaction.followup.send(
+                "You have left the team. Since there are no members left, the channels will be deleted.",
+                ephemeral=True,
+            )
+            return
 
     @app_commands.command(
         name="invite", description="Invite another member into your team!"

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -15,7 +15,7 @@ async def remove_member_from_team(
     guild = interaction.guild
 
     # get player object from member
-    player = await get_player(str(member.id))
+    player = await get_player(member.id)
 
     if not player:
         if kicked:
@@ -39,7 +39,7 @@ async def remove_member_from_team(
     await member.remove_roles(role)
 
     # delete player
-    await remove_player(str(member.id))
+    await remove_player(member.id)
 
     # delete team if no more members
     team_members = await get_team_members(team_name)
@@ -55,9 +55,9 @@ async def remove_member_from_team(
             await interaction.followup.send("You have left the team.", ephemeral=True)
             return
 
-    category_channel = guild.get_channel(int(team.category_channel_id))
-    text_channel = guild.get_channel(int(team.text_channel_id))
-    voice_channel = guild.get_channel(int(team.voice_channel_id))
+    category_channel = guild.get_channel(team.category_channel_id)
+    text_channel = guild.get_channel(team.text_channel_id)
+    voice_channel = guild.get_channel(team.voice_channel_id)
 
     # delete roles and channels
     await text_channel.delete()

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -11,9 +11,9 @@ from src.models.player import Player
 async def get_team_channels(guild: discord.Guild, team_name: str):
     team = await get_team(team_name)
 
-    voice_channel = guild.get_channel(int(team.voice_channel_id))
-    text_channel = guild.get_channel(int(team.text_channel_id))
-    category_channel = guild.get_channel(int(team.category_channel_id))
+    voice_channel = guild.get_channel(team.voice_channel_id)
+    text_channel = guild.get_channel(team.text_channel_id)
+    category_channel = guild.get_channel(team.category_channel_id)
 
     return [voice_channel, text_channel, category_channel]
 

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -59,13 +59,13 @@ async def remove_member_from_team(guild: discord.Guild, member: discord.Member):
 
     team_name = player.team_name
 
-    channels = await get_team_channels(guild, team_name)
-
     # delete team if no more members
     team_members = await get_team_members(team_name)
 
     if team_members:
         return "removed"
+
+    channels = await get_team_channels(guild, team_name)
 
     # delete roles and channels
     await delete_roles_and_channels([role], channels)

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -1,0 +1,81 @@
+import discord
+
+from src.queries.player import get_player, remove_player
+from src.queries.team import get_team, get_team_members, remove_team
+
+
+# kicked: a True/False value that lets the function know whether the member
+# is leaving the team on their own or is being kicked from the team by
+# an admin
+async def remove_member_from_team(
+    interaction: discord.Interaction, member: discord.Member, kicked: bool
+):
+    await interaction.response.defer(ephemeral=True)
+
+    guild = interaction.guild
+
+    # get player object from member
+    player = await get_player(str(member.id))
+
+    if not player:
+        if kicked:
+            await interaction.followup.send(
+                f"{member.display_name} is not part of a team.", ephemeral=True
+            )
+            return
+        else:
+            await interaction.followup.send(
+                "You are not part of a team.", ephemeral=True
+            )
+            return
+
+    team_name = player.team_name
+
+    team = await get_team(team_name)
+    team_role_id = int(team.team_role_id)
+    role = guild.get_role(team_role_id)
+
+    # remove their team role
+    await member.remove_roles(role)
+
+    # delete player
+    await remove_player(str(member.id))
+
+    # delete team if no more members
+    team_members = await get_team_members(team_name)
+
+    if team_members:
+        if kicked:
+            await interaction.followup.send(
+                f"{member.display_name} has been successfully kicked from {team_name}.",
+                ephemeral=True,
+            )
+            return
+        else:
+            await interaction.followup.send("You have left the team.", ephemeral=True)
+            return
+
+    category_channel = guild.get_channel(int(team.category_channel_id))
+    text_channel = guild.get_channel(int(team.text_channel_id))
+    voice_channel = guild.get_channel(int(team.voice_channel_id))
+
+    # delete roles and channels
+    await text_channel.delete()
+    await voice_channel.delete()
+    await category_channel.delete()
+    await role.delete()
+
+    await remove_team(team_name)
+
+    if kicked:
+        await interaction.followup.send(
+            f"{member.display_name} has been successfully kicked from {team_name}. "
+            + "Since the team is empty, the corresponding roles and channels will be deleted.",
+            ephemeral=True,
+        )
+        return
+    else:
+        await interaction.followup.send(
+            "You have left the team. Since there are no members left in the team, the channels will be deleted.",
+            ephemeral=True,
+        )

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -1,7 +1,22 @@
 import discord
 
+from typing import List
+
 from src.queries.player import get_player, remove_player
 from src.queries.team import get_team, get_team_members, remove_team
+
+
+async def delete_roles_and_channels(
+    roles: List[discord.Role],
+    channels: List[
+        discord.TextChannel | discord.VoiceChannel | discord.CategoryChannel
+    ],
+):
+    for role in roles:
+        await role.delete()
+
+    for channel in channels:
+        await channel.delete()
 
 
 # kicked: a True/False value that lets the function know whether the member
@@ -60,10 +75,9 @@ async def remove_member_from_team(
     voice_channel = guild.get_channel(team.voice_channel_id)
 
     # delete roles and channels
-    await text_channel.delete()
-    await voice_channel.delete()
-    await category_channel.delete()
-    await role.delete()
+    await delete_roles_and_channels(
+        [role], [text_channel, voice_channel, category_channel]
+    )
 
     await remove_team(team_name)
 

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -5,16 +5,17 @@ from typing import List
 from src.queries.player import get_player, remove_player
 from src.queries.team import get_team, get_team_members, remove_team
 
+from src.models.player import Player
 
-async def get_team_role_and_channels(guild: discord.Guild, team_name: str):
+
+async def get_team_channels(guild: discord.Guild, team_name: str):
     team = await get_team(team_name)
-    role = guild.get_role(int(team.team_role_id))
 
-    voice_channel = await guild.get_channel(int(team.voice_channel_id))
-    text_channel = await guild.get_channel(int(team.text_channel_id))
-    category_channel = await guild.get_channel(int(team.category_channel_id))
+    voice_channel = guild.get_channel(int(team.voice_channel_id))
+    text_channel = guild.get_channel(int(team.text_channel_id))
+    category_channel = guild.get_channel(int(team.category_channel_id))
 
-    return role, [voice_channel, text_channel, category_channel]
+    return [voice_channel, text_channel, category_channel]
 
 
 async def delete_roles_and_channels(
@@ -30,69 +31,45 @@ async def delete_roles_and_channels(
         await channel.delete()
 
 
+async def remove_role_and_player(
+    guild: discord.Guild, player: Player, member: discord.Member
+):
+    if not player:
+        return None
+
+    team = await get_team(player.team_name)
+    role = guild.get_role(team.team_role_id)
+
+    await member.remove_roles(role)
+    await remove_player(member.id)
+
+    return role
+
+
 # kicked: a True/False value that lets the function know whether the member
 # is leaving the team on their own or is being kicked from the team by
 # an admin
-async def remove_member_from_team(
-    interaction: discord.Interaction, member: discord.Member, kicked: bool
-):
-    await interaction.response.defer(ephemeral=True)
-
-    guild = interaction.guild
-
-    # get player object from member
+async def remove_member_from_team(guild: discord.Guild, member: discord.Member):
     player = await get_player(member.id)
 
-    if not player:
-        if kicked:
-            await interaction.followup.send(
-                f"{member.display_name} is not part of a team.", ephemeral=True
-            )
-            return
-        else:
-            await interaction.followup.send(
-                "You are not part of a team.", ephemeral=True
-            )
-            return
+    role = await remove_role_and_player(guild, player, member)
+
+    if not role:
+        return None
 
     team_name = player.team_name
 
-    role, channels = await get_team_role_and_channels(guild, team_name)
-
-    # remove their team role
-    await member.remove_roles(role)
-
-    # delete player
-    await remove_player(member.id)
+    channels = await get_team_channels(guild, team_name)
 
     # delete team if no more members
     team_members = await get_team_members(team_name)
 
     if team_members:
-        if kicked:
-            await interaction.followup.send(
-                f"{member.display_name} has been successfully kicked from {team_name}.",
-                ephemeral=True,
-            )
-            return
-        else:
-            await interaction.followup.send("You have left the team.", ephemeral=True)
-            return
+        return "removed"
 
     # delete roles and channels
     await delete_roles_and_channels([role], channels)
 
     await remove_team(team_name)
 
-    if kicked:
-        await interaction.followup.send(
-            f"{member.display_name} has been successfully kicked from {team_name}. "
-            + "Since the team is empty, the corresponding roles and channels will be deleted.",
-            ephemeral=True,
-        )
-        return
-    else:
-        await interaction.followup.send(
-            "You have left the team. Since there are no members left in the team, the channels will be deleted.",
-            ephemeral=True,
-        )
+    return "deleted"


### PR DESCRIPTION
This is an important ability so that team members that are causing grievances can be removed from a team that they may otherwise be unwilling to leave.

EDIT:
Upon abstracting the code for removing players from a team (since the code for kicking a player is largely the same as a player leaving by themself), we encountered CommandInvokeErrors. 
Specifically
`discord.app_commands.errors.CommandInvokeError: Command 'kick_member' raised an exception: NotFound: 404 Not Found (error code: 10008): Unknown Message`

This happens when the code attempts to respond to an interaction in a channel that has been deleted. This did not occur before the abstraction of code because the interaction received a response before the channels were deleted. However, post-abstraction the folllowup response is only sent after the deletion of channels. This is a little hard to get around. We can possibly leave the actual deletion of the channels to the individual cog commands but that is not an ideal solution. We can also pass in the interaction to the context command and allow it to respond to the interaction. 

However, we've chosen to simply catch the error when it happens and ignore it.