### PR TITLE
Add member

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -259,6 +259,19 @@ class Admin(commands.GroupCog):
             f"{member.display_name} is now part of the {team_name}!", ephemeral=True
         )
 
+    @app_commands.command(
+        name="get_team_name",
+        description="Gets the team name of the current channel you're in.",
+    )
+    @commands.has_role(EXEC_ID)
+    async def get_team_name(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+
+        category = interaction.channel.category
+        vc = category.voice_channels[0]
+
+        await interaction.followup.send(vc.name)
+
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(Admin(bot))

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -15,7 +15,7 @@ from src.queries.puzzle import (
     create_puzzle,
     delete_puzzle,
 )
-from src.queries.player import get_player, remove_player
+from src.queries.player import get_player, remove_player, add_player
 from src.queries.team import get_team, get_team_members, remove_team
 
 from src.config import config
@@ -23,6 +23,7 @@ from src.config import config
 from src.context.team import remove_member_from_team
 
 EXEC_ID = "Executives"
+MAX_TEAM_SIZE = 6
 
 
 class Admin(commands.GroupCog):
@@ -212,6 +213,48 @@ class Admin(commands.GroupCog):
                 return
 
             return
+
+    @app_commands.command(
+        name="add_member",
+        description="Adds someone to a team. Only use this when they are unable to be invited.",
+    )
+    @commands.has_role(EXEC_ID)
+    async def add_member(
+        self, interaction: discord.Interaction, member: discord.Member, team_name: str
+    ):
+        await interaction.response.defer(ephemeral=True)
+
+        guild = interaction.guild
+
+        player = await get_player(member.id)
+        if player:
+            await interaction.followup.send(
+                f"{member.display_name} is already in a team.", ephemeral=True
+            )
+            return
+
+        team = await get_team(team_name)
+        if not team:
+            await interaction.followup.send(
+                f"{team_name} does not exist. Did you type the name correctly?",
+                ephemeral=True,
+            )
+            return
+
+        team_members = await get_team_members(team_name)
+        if len(team_members) == MAX_TEAM_SIZE:
+            await interaction.followup.send(f"{team_name} is full!", ephemeral=True)
+            return
+
+        # if all checks pass, add the member to the team
+        await add_player(member.id, team_name)
+
+        # give member the team role
+        await member.add_roles(guild.get_role(team.team_role_id))
+
+        await interaction.followup.send(
+            f"{member.display_name} is now part of the {team_name}!", ephemeral=True
+        )
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -220,7 +220,10 @@ class Admin(commands.GroupCog):
     )
     @commands.has_role(EXEC_ID)
     async def add_member(
-        self, interaction: discord.Interaction, member: discord.Member, team_name: str
+        self,
+        interaction: discord.Interaction,
+        member: discord.Member,
+        team_name: str,
     ):
         await interaction.response.defer(ephemeral=True)
 

--- a/cogs/team.py
+++ b/cogs/team.py
@@ -222,10 +222,17 @@ class Team(commands.GroupCog):
         accept_btn.callback = accept_callback
         reject_btn.callback = reject_callback
 
-        await invited_user.send(embed=embed, view=view)
-        await interaction.followup.send(
-            f"{invited_user} has been invited to your team.", ephemeral=True
-        )
+        try:
+            await invited_user.send(embed=embed, view=view)
+            await interaction.followup.send(
+                f"{invited_user.display_name} has been invited to your team.",
+                ephemeral=True,
+            )
+        except CommandInvokeError:
+            await interaction.followup.send(
+                f"{invited_user.display_name} cannot be invited. This may be because they can't receive DMs from this bot."
+                + "Tag an exec and they can add the member to your team for you!"
+            )
 
 
 async def setup(bot: commands.Bot):

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -46,9 +46,6 @@ async def remove_role_and_player(
     return role
 
 
-# kicked: a True/False value that lets the function know whether the member
-# is leaving the team on their own or is being kicked from the team by
-# an admin
 async def remove_member_from_team(guild: discord.Guild, member: discord.Member):
     player = await get_player(member.id)
 


### PR DESCRIPTION
Not 100% sure of the exact problem but it seems that some people have their settings such that they can't receive DMs from the bot. No real way around this apart from adding a command that allows execs to add the member to the team. 

Unfortunately some teams do have some long and confusing names so I've added a command that sends the name of the team (except it really only just looks at the name of the corresponding voice channel of the text channel that the command is run in). The voice channel is the only one out of the channels that stores the exact name and does not alter by replacing spaces with dashes or making everything the same case. This is just a quick fix for the problem but if it proves to be inconvenient we may need to write a new query that returns the team name.