### PR TITLE
Leaderboard

### DIFF
--- a/cogs/puzzle.py
+++ b/cogs/puzzle.py
@@ -64,32 +64,6 @@ class Puzzle(commands.GroupCog):
     def update_leaderboard(self, new_embeds: list[discord.Embed]):
         self.leaderboard_embeds = new_embeds
 
-    @discord.ui.button(custom_id="next")
-    async def prev_button(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
-        await interaction.response.defer()
-        if self.page_num > 0:
-            self.page_num += -1
-
-        await interaction.followup.edit_message(
-            message_id=interaction.message.id,
-            embed=self.leaderboard_embeds[self.page_num],
-        )
-
-    @discord.ui.button(custom_id="next")
-    async def next_button(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
-        await interaction.response.defer()
-        if self.page_num < len(self.leaderboard_embeds) - 1:
-            self.page_num += 1
-
-        await interaction.followup.edit_message(
-            message_id=interaction.message.id,
-            embed=self.leaderboard_embeds[self.page_num],
-        )
-
     @app_commands.command(name="submit", description="Submit an answer to a puzzle")
     @in_team_channel
     async def submit_answer(
@@ -213,7 +187,7 @@ class Puzzle(commands.GroupCog):
         await interaction.response.defer()
 
         leaderboard_values = await get_leaderboard()
-        TEAMS_PER_EMBED = 10
+        TEAMS_PER_EMBED = 1
         num_vals = len(leaderboard_values)
         if num_vals == 0:
             await interaction.followup.send("There are no teams at this time.")

--- a/cogs/puzzle.py
+++ b/cogs/puzzle.py
@@ -13,7 +13,7 @@ from src.queries.submission import (
     find_submissions_by_discord_id_and_puzzle_id,
 )
 from src.queries.player import get_player
-from src.queries.team import get_team, get_team_members
+from src.queries.team import get_team, get_team_members, increase_puzzles_solved
 
 from src.utils.decorators import in_team_channel
 from src.context.puzzle import can_access_puzzle, get_accessible_puzzles
@@ -125,6 +125,8 @@ class Puzzle(commands.GroupCog):
 
         if not submission_is_correct:
             return await interaction.followup.send("The submitted answer is incorrect!")
+        else:
+            await increase_puzzles_solved(player.team_name)
 
         # check if they have solved all the metas
         if puzzle_id == "UTS-M":
@@ -211,7 +213,7 @@ class Puzzle(commands.GroupCog):
         await interaction.response.defer()
 
         leaderboard_values = await get_leaderboard()
-        TEAMS_PER_EMBED = 2
+        TEAMS_PER_EMBED = 10
         num_vals = len(leaderboard_values)
         if num_vals == 0:
             await interaction.followup.send("There are no teams at this time.")
@@ -228,7 +230,9 @@ class Puzzle(commands.GroupCog):
         leaderboard_embeds = [
             discord.Embed(
                 title="Leaderboard",
-                description="Teams are sorted by the number of puzzles solved. Ties are broken by the latest correct submission time for each tied team.",
+                description="Teams are sorted by the number of puzzles solved."
+                + "Ties are broken by the latest correct submission time for each tied team.",
+                color=discord.Color.random(),
             )
             for _ in range(num_embeds)
         ]

--- a/cogs/puzzle.py
+++ b/cogs/puzzle.py
@@ -187,7 +187,7 @@ class Puzzle(commands.GroupCog):
         await interaction.response.defer()
 
         leaderboard_values = await get_leaderboard()
-        TEAMS_PER_EMBED = 1
+        TEAMS_PER_EMBED = 10
         num_vals = len(leaderboard_values)
         if num_vals == 0:
             await interaction.followup.send("There are no teams at this time.")

--- a/cogs/puzzle.py
+++ b/cogs/puzzle.py
@@ -246,7 +246,6 @@ class Puzzle(commands.GroupCog):
 
             leaderboard_text[i // TEAMS_PER_EMBED] = (team_str, puzzles_solved_str)
 
-        print(leaderboard_text)
         for page_num, embed in enumerate(leaderboard_embeds):
             embed.add_field(name="Team", value=leaderboard_text[page_num][0])
             embed.add_field(name="Puzzles Solved", value=leaderboard_text[page_num][1])

--- a/cogs/puzzle.py
+++ b/cogs/puzzle.py
@@ -63,9 +63,6 @@ class Puzzle(commands.GroupCog):
     def __init__(self, bot):
         self.bot = bot
 
-    def update_leaderboard(self, new_embeds: list[discord.Embed]):
-        self.leaderboard_embeds = new_embeds
-
     @app_commands.command(name="submit", description="Submit an answer to a puzzle")
     @in_team_channel
     async def submit_answer(
@@ -106,8 +103,8 @@ class Puzzle(commands.GroupCog):
 
         if not submission_is_correct:
             return await interaction.followup.send("The submitted answer is incorrect!")
-        else:
-            await increase_puzzles_solved(player.team_name)
+
+        await increase_puzzles_solved(player.team_name)
 
         # check if they have solved all the metas
         if puzzle_id == "UTS-M":

--- a/cogs/team.py
+++ b/cogs/team.py
@@ -105,7 +105,7 @@ class Team(commands.GroupCog):
                     "You have left the team. Since there are no members left, the channels will be deleted.",
                     ephemeral=True,
                 )
-            except CommandInvokeError:
+            except discord.errors.NotFound:
                 return
 
             return

--- a/src/queries/puzzle.py
+++ b/src/queries/puzzle.py
@@ -130,14 +130,14 @@ async def delete_puzzle(puzzle_id: str):
     return True
 
 
-async def get_leaderboard():
+async def get_leaderboard() -> tuple[str, int]:
     aconn = await psycopg.AsyncConnection.connect(DATABASE_URL)
-    acur = aconn.cursor(row_factory=dict_row)
+    acur = aconn.cursor()
 
     await acur.execute(
         """
         SELECT t.team_name, t.puzzle_solved
-        FROM public.teams AS t JOIN public.submissions AS s
+        FROM public.teams AS t LEFT JOIN public.submissions AS s
         ON (t.team_name = s.team_name)
         ORDER BY t.puzzle_solved DESC, s.submission_time ASC
         """

--- a/src/queries/puzzle.py
+++ b/src/queries/puzzle.py
@@ -139,7 +139,9 @@ async def get_leaderboard() -> tuple[str, int]:
         SELECT t.team_name, t.puzzle_solved
         FROM public.teams AS t LEFT JOIN public.submissions AS s
         ON (t.team_name = s.team_name)
-        ORDER BY t.puzzle_solved DESC, s.submission_time ASC
+        AND s.submission_is_correct = TRUE
+        GROUP BY t.team_name
+        ORDER BY t.puzzle_solved DESC, MAX(s.submission_time) ASC
         """
     )
 

--- a/src/queries/puzzle.py
+++ b/src/queries/puzzle.py
@@ -143,7 +143,7 @@ async def get_leaderboard():
         """
     )
 
-    leaderboard = acur.fetchall()
+    leaderboard = await acur.fetchall()
 
     await acur.close()
     await aconn.close()

--- a/src/queries/puzzle.py
+++ b/src/queries/puzzle.py
@@ -141,7 +141,7 @@ async def get_leaderboard() -> tuple[str, int]:
         ON (t.team_name = s.team_name)
         AND s.submission_is_correct = TRUE
         GROUP BY t.team_name
-        ORDER BY t.puzzle_solved DESC, MAX(s.submission_time) ASC
+        ORDER BY t.puzzle_solved DESC, MAX(s.submission_time) ASC, t.team_name ASC
         """
     )
 

--- a/src/queries/team.py
+++ b/src/queries/team.py
@@ -112,25 +112,13 @@ async def increase_puzzles_solved(team_name: str):
     if not await get_team(team_name):
         return False
 
-    # get the current number of solved puzzles by the team
-    await acur.execute(
-        """
-        SELECT t.puzzle_solved
-        FROM public.teams AS t
-        WHERE t.team_name = %s
-        """,
-        (team_name,),
-    )
-
-    puzzles_solved = (await acur.fetchone())[0]
-
     await acur.execute(
         """
         UPDATE public.teams
-        SET puzzle_solved = %s
+        SET puzzle_solved = puzzle_solved + 1
         WHERE team_name = %s
         """,
-        (puzzles_solved + 1, team_name),
+        (team_name,),
     )
 
     await aconn.commit()

--- a/src/queries/team.py
+++ b/src/queries/team.py
@@ -101,3 +101,38 @@ async def remove_team(team_name: str):
     await aconn.commit()
     await acur.close()
     await aconn.close()
+
+
+async def increase_puzzles_solved(team_name: str):
+    aconn = await psycopg.AsyncConnection.connect(DATABASE_URL)
+    acur = aconn.cursor()
+
+    # this should never run since the team name should always be
+    # valid when calling this function
+    if not await get_team(team_name):
+        return False
+
+    # get the current number of solved puzzles by the team
+    await acur.execute(
+        """
+        SELECT t.puzzle_solved
+        FROM public.teams AS t
+        WHERE t.team_name = %s
+        """,
+        (team_name,),
+    )
+
+    puzzles_solved = (await acur.fetchone())[0]
+    print(puzzles_solved)
+
+    await acur.execute(
+        """
+        UPDATE public.teams
+        SET puzzle_solved = %s
+        """,
+        (puzzles_solved + 1,),
+    )
+
+    await aconn.commit()
+    await acur.close()
+    await aconn.close()

--- a/src/queries/team.py
+++ b/src/queries/team.py
@@ -123,7 +123,6 @@ async def increase_puzzles_solved(team_name: str):
     )
 
     puzzles_solved = (await acur.fetchone())[0]
-    print(puzzles_solved)
 
     await acur.execute(
         """

--- a/src/queries/team.py
+++ b/src/queries/team.py
@@ -129,8 +129,9 @@ async def increase_puzzles_solved(team_name: str):
         """
         UPDATE public.teams
         SET puzzle_solved = %s
+        WHERE team_name = %s
         """,
-        (puzzles_solved + 1,),
+        (puzzles_solved + 1, team_name),
     )
 
     await aconn.commit()


### PR DESCRIPTION
Added a command to show the leaderboard of the current teams. Ties between teams will be broken by the latest correct submission time. E.g Team A and B have both solved the same amount of puzzles but team B will show up higher than A because the latest puzzle they solved was at an earlier time than the latest puzzle A solved.

Also fixed the issue for submission where the number of puzzles a team solved was not updated in the public.teams table.