### PR TITLE
Updating hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To start the local database, simply do:
 This will start a local database that runs on port 5432 and store its data in a local pg_data directory.
 To connect to the docker database, do:
 
-    docker exec -it postgres16 psql -U postgres
+    docker exec -it postgres16 psql -U postgres -d puzzlehunt_bot
 
 For future maintainer, since the infra we're curerntly using is Fly.io:
 To run the schema on remote fly machine, open a tunnel with `fly proxy`, then use `psql` with -f and -h flags (-h flags forces psql to use TCP/IP instead of UNIX sockets)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -220,12 +220,13 @@ class Admin(commands.GroupCog):
     )
     @commands.has_role(EXEC_ID)
     async def add_member(
-        self,
-        interaction: discord.Interaction,
-        member: discord.Member,
-        team_name: str,
+        self, interaction: discord.Interaction, member: discord.Member
     ):
         await interaction.response.defer(ephemeral=True)
+
+        category = interaction.channel.category
+        vc = category.voice_channels[0]
+        team_name = vc.name
 
         guild = interaction.guild
 
@@ -239,7 +240,8 @@ class Admin(commands.GroupCog):
         team = await get_team(team_name)
         if not team:
             await interaction.followup.send(
-                f"{team_name} does not exist. Did you type the name correctly?",
+                f"This channel does not belong to a team. "
+                + "Did you type the command in the correct channel?",
                 ephemeral=True,
             )
             return
@@ -258,19 +260,6 @@ class Admin(commands.GroupCog):
         await interaction.followup.send(
             f"{member.display_name} is now part of the {team_name}!", ephemeral=True
         )
-
-    @app_commands.command(
-        name="get_team_name",
-        description="Gets the team name of the current channel you're in.",
-    )
-    @commands.has_role(EXEC_ID)
-    async def get_team_name(self, interaction: discord.Interaction):
-        await interaction.response.defer(ephemeral=True)
-
-        category = interaction.channel.category
-        vc = category.voice_channels[0]
-
-        await interaction.followup.send(vc.name)
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/puzzle.py
+++ b/cogs/puzzle.py
@@ -203,7 +203,7 @@ class Puzzle(commands.GroupCog):
 
         max_hints = await check_if_max_hints(player.team_name)
         if max_hints:
-            next_hint_time = await get_next_hint_time()
+            next_hint_time = get_next_hint_time()
             await interaction.followup.send(
                 "You have used up all your available hints! "
                 + f"Next hint at {next_hint_time}. A new hint is available every hour."

--- a/cogs/puzzle.py
+++ b/cogs/puzzle.py
@@ -185,9 +185,14 @@ class Puzzle(commands.GroupCog):
         embed.add_field(name="Puzzles", value="\n".join(puzzle_name_links), inline=True)
         await interaction.followup.send(embed=embed)
 
-    @app_commands.command(name="hint", description="Request a hint for the puzzle!")
+    @app_commands.command(
+        name="hint",
+        description="Request a hint for the puzzle! Please be detailed about what you're stuck on.",
+    )
     @in_team_channel
-    async def hint(self, interaction: discord.Interaction):
+    async def hint(
+        self, interaction: discord.Interaction, puzzle_name: str, hint_msg: str
+    ):
         await interaction.response.defer()
 
         if datetime.now(tz=ZoneInfo("Australia/Sydney")) < config["HUNT_START_TIME"]:
@@ -208,9 +213,19 @@ class Puzzle(commands.GroupCog):
 
         await increase_hints_used(player.team_name)
 
-        await interaction.client.get_channel(config["ADMIN_CHANNEL_ID"]).send(
-            f"Hint request submitted from team {player.team_name}! {interaction.channel.mention}"
+        hint_embed = discord.Embed(
+            colour=discord.Color.dark_teal(),
+            title=f"Hint Request From {interaction.channel.mention}",
+            description=f"**Puzzle Name:** {puzzle_name}",
         )
+
+        if hint_msg:
+            hint_embed.add_field(name="Details", value=hint_msg)
+
+        await interaction.client.get_channel(config["ADMIN_CHANNEL_ID"]).send(
+            embed=hint_embed
+        )
+
         await interaction.followup.send(
             "Your hint request has been submitted! Hang on tight - a hint giver will be with you shortly."
         )

--- a/cogs/puzzle.py
+++ b/cogs/puzzle.py
@@ -134,8 +134,15 @@ class Puzzle(commands.GroupCog):
 
         elif puzzle_id == "METAMETA":
             team = await get_team(player.team_name)
+
+            victory_embed = discord.Embed(
+                colour=discord.Color.gold(),
+                title=f"Team <#{team.text_channel_id}> has finished the hunt!",
+                description=f"Congratulate them over in the <#{config['VICTOR_TEXT_CHANNEL_ID']}>",
+            )
+
             await interaction.client.get_channel(config["ADMIN_CHANNEL_ID"]).send(
-                f"Team <#{team.text_channel_id}> has finished all the puzzles!"
+                embed=victory_embed
             )
 
             # give team the victor role

--- a/cogs/team.py
+++ b/cogs/team.py
@@ -9,7 +9,7 @@ import src.queries.player as player_query
 from src.config import config
 
 from src.context.puzzle import get_accessible_puzzles
-from src.context.team import remove_member_from_team
+from src.context.team import remove_member_from_team, get_max_hints, get_next_hint_time
 
 from src.utils.decorators import in_team_channel
 
@@ -255,6 +255,14 @@ class Team(commands.GroupCog):
             name="Puzzle Status",
             value=f"You have solved {team.puzzle_solved} puzzles "
             + f"out of {len(accessible_puzzles)} available!",
+        )
+
+        max_hints = await get_max_hints()
+        next_hint_time = await get_next_hint_time()
+        info_embed.add_field(
+            name="Hint Status",
+            value=f"You have used {team.hints_used} out of {max_hints} available. "
+            + f"Next hint at {next_hint_time}.",
         )
 
         await interaction.followup.send(embed=info_embed)

--- a/cogs/team.py
+++ b/cogs/team.py
@@ -9,7 +9,12 @@ import src.queries.player as player_query
 from src.config import config
 
 from src.context.puzzle import get_accessible_puzzles
-from src.context.team import remove_member_from_team, get_max_hints, get_next_hint_time
+from src.context.team import (
+    remove_member_from_team,
+    get_max_hints,
+    get_next_hint_time,
+    get_finished_teams,
+)
 
 from src.utils.decorators import in_team_channel
 
@@ -257,13 +262,20 @@ class Team(commands.GroupCog):
             + f"out of {len(accessible_puzzles)} available!",
         )
 
-        max_hints = await get_max_hints()
-        next_hint_time = await get_next_hint_time()
-        info_embed.add_field(
-            name="Hint Status",
-            value=f"You have used {team.hints_used} out of {max_hints} available. "
-            + f"Next hint at {next_hint_time}.",
-        )
+        finished_teams = await get_finished_teams()
+        if len(finished_teams) >= 1:
+            info_embed.add_field(
+                name="Hint Status",
+                value=f"Hints are now unlimited! You have used {team.hints_used} hints.",
+            )
+        else:
+            max_hints = get_max_hints()
+            next_hint_time = get_next_hint_time()
+            info_embed.add_field(
+                name="Hint Status",
+                value=f"You have used {team.hints_used} out of {max_hints} available. "
+                + f"Next hint at {next_hint_time}.",
+            )
 
         await interaction.followup.send(embed=info_embed)
 

--- a/cogs/team.py
+++ b/cogs/team.py
@@ -263,7 +263,7 @@ class Team(commands.GroupCog):
         )
 
         finished_teams = await get_finished_teams()
-        if len(finished_teams) >= 1:
+        if len(finished_teams) >= 3:
             info_embed.add_field(
                 name="Hint Status",
                 value=f"Hints are now unlimited! You have used {team.hints_used} hints.",

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -3,6 +3,7 @@ import discord
 from typing import List
 
 from src.queries.player import get_player, remove_player
+from queries.puzzle import get_finished_teams
 from src.queries.team import get_team, get_team_members, remove_team
 
 from src.models.player import Player
@@ -77,3 +78,4 @@ async def check_if_max_hints(team_name: str):
 
     # check if top 3 has been taken
     # unlimited hints if so and we just return False
+    finished_teams = await get_finished_teams()

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -3,10 +3,17 @@ import discord
 from typing import List
 
 from src.queries.player import get_player, remove_player
-from queries.puzzle import get_finished_teams
+from src.queries.puzzle import get_finished_teams
 from src.queries.team import get_team, get_team_members, remove_team
 
 from src.models.player import Player
+
+from src.config import config
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+SECONDS_IN_AN_HOUR = 3600
 
 
 async def get_team_channels(guild: discord.Guild, team_name: str):
@@ -79,3 +86,29 @@ async def check_if_max_hints(team_name: str):
     # check if top 3 has been taken
     # unlimited hints if so and we just return False
     finished_teams = await get_finished_teams()
+    if len(finished_teams) >= 3:
+        return False
+
+    # check how many hints would be available
+    # if no hints were used
+    # hints are given out 1 per hour
+    # so total number of hints that would be available
+    # is the same as the number of hours that have passed
+    time_difference = (
+        datetime.now(tz=ZoneInfo("Australia/Sydney")) - config["HUNT_START_TIME"]
+    )
+    total_hints = time_difference.seconds // SECONDS_IN_AN_HOUR
+    if team.hints_used < total_hints:
+        return False
+
+    return True
+
+
+async def get_next_hint_time() -> str:
+    time_difference = (
+        datetime.now(tz=ZoneInfo("Australia/Sydney")) - config["HUNT_START_TIME"]
+    )
+    hours_passed = time_difference.seconds // SECONDS_IN_AN_HOUR
+
+    next_hint_time = config["HUNT_START_TIME"] + timedelta(hours=hours_passed + 1)
+    return next_hint_time.strftime("%H:%M")

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -13,6 +13,7 @@ from src.config import config
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+SECONDS_BETWEEN_HINTS = 7200  # how many seconds between each new hint
 SECONDS_IN_AN_HOUR = 3600
 
 
@@ -84,7 +85,7 @@ def get_max_hints():
     time_difference = (
         datetime.now(tz=ZoneInfo("Australia/Sydney")) - config["HUNT_START_TIME"]
     )
-    max_hints = time_difference.seconds // SECONDS_IN_AN_HOUR
+    max_hints = time_difference.seconds // SECONDS_BETWEEN_HINTS
 
     return max_hints
 
@@ -114,7 +115,9 @@ def get_next_hint_time() -> str:
     time_difference = (
         datetime.now(tz=ZoneInfo("Australia/Sydney")) - config["HUNT_START_TIME"]
     )
-    hours_passed = time_difference.seconds // SECONDS_IN_AN_HOUR
+    hours_passed = time_difference.seconds // SECONDS_BETWEEN_HINTS
 
-    next_hint_time = config["HUNT_START_TIME"] + timedelta(hours=hours_passed + 1)
+    next_hint_time = config["HUNT_START_TIME"] + timedelta(
+        hours=hours_passed + (SECONDS_BETWEEN_HINTS // SECONDS_IN_AN_HOUR)
+    )
     return next_hint_time.strftime("%H:%M")

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -89,12 +89,12 @@ def get_max_hints():
     return max_hints
 
 
-def check_if_max_hints(team_name: str):
-    team = get_team(team_name)
+async def check_if_max_hints(team_name: str):
+    team = await get_team(team_name)
 
     # check if top 3 has been taken
     # unlimited hints if so and we just return False
-    finished_teams = get_finished_teams()
+    finished_teams = await get_finished_teams()
     if len(finished_teams) >= 3:
         return False
 
@@ -110,7 +110,7 @@ def check_if_max_hints(team_name: str):
     return True
 
 
-async def get_next_hint_time() -> str:
+def get_next_hint_time() -> str:
     time_difference = (
         datetime.now(tz=ZoneInfo("Australia/Sydney")) - config["HUNT_START_TIME"]
     )

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -70,3 +70,10 @@ async def remove_member_from_team(guild: discord.Guild, member: discord.Member):
     await remove_team(team_name)
 
     return "deleted"
+
+
+async def check_if_max_hints(team_name: str):
+    team = await get_team(team_name)
+
+    # check if top 3 has been taken
+    # unlimited hints if so and we just return False

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -80,6 +80,15 @@ async def remove_member_from_team(guild: discord.Guild, member: discord.Member):
     return "deleted"
 
 
+async def get_max_hints():
+    time_difference = (
+        datetime.now(tz=ZoneInfo("Australia/Sydney")) - config["HUNT_START_TIME"]
+    )
+    max_hints = time_difference.seconds // SECONDS_IN_AN_HOUR
+
+    return max_hints
+
+
 async def check_if_max_hints(team_name: str):
     team = await get_team(team_name)
 
@@ -94,10 +103,7 @@ async def check_if_max_hints(team_name: str):
     # hints are given out 1 per hour
     # so total number of hints that would be available
     # is the same as the number of hours that have passed
-    time_difference = (
-        datetime.now(tz=ZoneInfo("Australia/Sydney")) - config["HUNT_START_TIME"]
-    )
-    total_hints = time_difference.seconds // SECONDS_IN_AN_HOUR
+    total_hints = await get_max_hints()
     if team.hints_used < total_hints:
         return False
 

--- a/src/context/team.py
+++ b/src/context/team.py
@@ -80,7 +80,7 @@ async def remove_member_from_team(guild: discord.Guild, member: discord.Member):
     return "deleted"
 
 
-async def get_max_hints():
+def get_max_hints():
     time_difference = (
         datetime.now(tz=ZoneInfo("Australia/Sydney")) - config["HUNT_START_TIME"]
     )
@@ -89,12 +89,12 @@ async def get_max_hints():
     return max_hints
 
 
-async def check_if_max_hints(team_name: str):
-    team = await get_team(team_name)
+def check_if_max_hints(team_name: str):
+    team = get_team(team_name)
 
     # check if top 3 has been taken
     # unlimited hints if so and we just return False
-    finished_teams = await get_finished_teams()
+    finished_teams = get_finished_teams()
     if len(finished_teams) >= 3:
         return False
 
@@ -103,7 +103,7 @@ async def check_if_max_hints(team_name: str):
     # hints are given out 1 per hour
     # so total number of hints that would be available
     # is the same as the number of hours that have passed
-    total_hints = await get_max_hints()
+    total_hints = get_max_hints()
     if team.hints_used < total_hints:
         return False
 

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE public.teams (
     text_channel_id text NOT NULL,
     team_role_id text NOT NULL,
     puzzle_solved integer NOT NULL default 0
+    hints_used integer NOT NULL default 0
 );
 
 CREATE TABLE public.players (

--- a/src/models/team.py
+++ b/src/models/team.py
@@ -8,3 +8,4 @@ class Team(BaseModel):
     text_channel_id: int
     team_role_id: int
     puzzle_solved: int
+    hints_used: int

--- a/src/queries/puzzle.py
+++ b/src/queries/puzzle.py
@@ -156,7 +156,7 @@ async def get_leaderboard() -> tuple[str, int]:
 
 async def get_finished_teams():
     aconn = await psycopg.AsyncConnection.connect(DATABASE_URL)
-    acur = aconn.cursor(row_factory=class_row(Team))
+    acur = aconn.cursor()
 
     await acur.execute(
         """

--- a/src/queries/puzzle.py
+++ b/src/queries/puzzle.py
@@ -163,7 +163,7 @@ async def get_finished_teams():
         SELECT t.team_name
         FROM public.teams AS t JOIN public.submissions AS s
         ON (t.team_name = s.team_name)
-        WHERE s.puzzle_id = METAMETA AND s.submission_is_correct = TRUE
+        WHERE s.puzzle_id = 'METAMETA' AND s.submission_is_correct = TRUE
         """
     )
 

--- a/src/queries/puzzle.py
+++ b/src/queries/puzzle.py
@@ -4,6 +4,7 @@ from psycopg.rows import class_row, dict_row
 
 from src.config import config
 from src.models.puzzle import Puzzle
+from src.models.team import Team
 
 DATABASE_URL = config["DATABASE_URL"]
 
@@ -151,3 +152,24 @@ async def get_leaderboard() -> tuple[str, int]:
     await aconn.close()
 
     return leaderboard
+
+
+async def get_finished_teams():
+    aconn = await psycopg.AsyncConnection.connect(DATABASE_URL)
+    acur = aconn.cursor(row_factory=class_row(Team))
+
+    await acur.execute(
+        """
+        SELECT t.team_name
+        FROM public.teams AS t JOIN public.submissions AS s
+        ON (t.team_name = s.team_name)
+        WHERE s.puzzle_id = METAMETA AND s.submission_is_correct = TRUE
+        """
+    )
+
+    finished_teams = await acur.fetchall()
+
+    await acur.close()
+    await aconn.close()
+
+    return finished_teams

--- a/src/queries/team.py
+++ b/src/queries/team.py
@@ -124,3 +124,24 @@ async def increase_puzzles_solved(team_name: str):
     await aconn.commit()
     await acur.close()
     await aconn.close()
+
+
+async def increase_hints_used(team_name: str):
+    aconn = await psycopg.AsyncConnection.connect(DATABASE_URL)
+    acur = aconn.cursor()
+
+    if not await get_team(team_name):
+        return False
+
+    await acur.execute(
+        """
+        UPDATE public.teams
+        SET hints_used = hints_used + 1
+        WHERE team_name = %s
+        """,
+        (team_name,),
+    )
+
+    await aconn.commit()
+    await acur.close()
+    await aconn.close()


### PR DESCRIPTION
- public.teams table has been altered to include a `hints_used` column which is simply an int that keeps track of how many hints a team has used
- the `hints_used` counter is compared against the total amount of hints a team would have available which is calculated each time a team asks for a hint. The calculation is simply checking how many hours have elapsed since the starting time since hints are given out one per hour. 

IMPORTANT: Since the bot is already online, we will need to alter the table in the DB while it is running.

- also added a `/team info` command which simply sends an embed containing info on how many puzzles the team has solved as well as how many hints have been used out of those available.
- one more minor change is to the `/admin add_member` command. In the initial implementation, you would need to type the name of the team you're adding the member to. This was quite a hassle even with the command that sends the name of the team so you can copy and paste. I've fixed it so that the command assumes the team the member is being added to is the team that corresponds to the channel the command is used in.